### PR TITLE
[Fix] MemberStudySchedule 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
@@ -17,8 +17,12 @@ public interface MemberStudyScheduleRepository extends JpaRepository<MemberStudy
     SELECT mss
     FROM MemberStudySchedule mss
     JOIN FETCH mss.studySchedule ss
-    JOIN FETCH ss.studyGroup
+    JOIN FETCH ss.studyGroup sg
+    JOIN StudyGroupMember sgm
+      ON sgm.member.id = mss.member.id AND sgm.studyGroup.id = sg.id
     WHERE mss.member.id = :memberId
+      AND sgm.isAllowed = true
+      AND sgm.deleted = false
     """)
     List<MemberStudySchedule> findAllByMemberId(@Param("memberId") Long memberId);
 


### PR DESCRIPTION
## 📌 개요

스터디 그룹에서 멤버 강퇴 시, 해당 멤버의 일정 조회에서 제외되도록 쿼리 수정


## 🛠️ 작업 내용
- MemberStudySchedule 조회 쿼리에 deleted 조건 추가


## 📌 차후 계획 (Optional)

* (작업한 코드가 추후 우리 프로젝트에 어떤 영향을 끼칠지, 앞으로 PR계획을 설명해주세요)


## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 기존 테스트 통과 여부 확인
- [x] 강퇴된 멤버가 일정 조회 API 호출 시, 일정이 보이지 않는지 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---
closes #344 