### PR TITLE
[fix] 스터디 그룹 참가 인원 조회 및 스터디 그룹 스케쥴 조회 시 읽기 전용 트랜잭션과 비관적락의 충돌 해결

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -63,6 +63,7 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
   List<StudyGroup> findAllByCreator_IdOrderByCreatedAtDesc(Long memberId);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  Optional<StudyGroup> findById(Long id);
+  @Query("SELECT sg FROM StudyGroup sg WHERE sg.id = :id")
+  Optional<StudyGroup> findByIdForUpdate(@Param("id") Long id);;
 
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAdminService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAdminService.java
@@ -63,7 +63,7 @@ public class StudyGroupAdminService {
   @jakarta.transaction.Transactional
   public void acceptMember(Long studyGroupId, Long targetMemberId, Member requester) {
     // 스터디 존재 확인
-    StudyGroup group = studyGroupRepository.findById(studyGroupId)
+    StudyGroup group = studyGroupRepository.findByIdForUpdate(studyGroupId)
         .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
 
     // 요청자가 스터디장인지 확인
@@ -97,7 +97,7 @@ public class StudyGroupAdminService {
 
   @Transactional
   public void kickMember(StudyGroupKickRequest request, Member requester) {
-    StudyGroup group = studyGroupRepository.findById(request.getStudyGroupId())
+    StudyGroup group = studyGroupRepository.findByIdForUpdate(request.getStudyGroupId())
         .orElseThrow(() -> new StudyGroupNotFoundException(request.getStudyGroupId()));
 
     if (!group.getCreator().getId().equals(requester.getId())) {

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupInviteService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupInviteService.java
@@ -23,7 +23,7 @@ public class StudyGroupInviteService {
 
   @Transactional
   public void inviteByEmail(Member inviter, StudyGroupInviteRequest request) {
-    StudyGroup group = studyGroupRepository.findById(request.getStudyGroupId())
+    StudyGroup group = studyGroupRepository.findByIdForUpdate(request.getStudyGroupId())
         .orElseThrow(() -> new StudyGroupNotFoundException(request.getStudyGroupId()));
 
     if (!group.getCreator().getId().equals(inviter.getId())) {

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberService.java
@@ -68,7 +68,7 @@ public class StudyGroupMemberService {
 
   @Transactional
   public void requestToJoin(Member member, Long studyGroupId) {
-    StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
+    StudyGroup studyGroup = studyGroupRepository.findByIdForUpdate(studyGroupId)
         .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
 
     // 중복 요청 방지
@@ -95,7 +95,7 @@ public class StudyGroupMemberService {
 
   @Transactional
   public void leaveStudyGroup(Long studyGroupId, Member member) {
-    StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
+    StudyGroup studyGroup = studyGroupRepository.findByIdForUpdate(studyGroupId)
         .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
 
     StudyGroupMember studyGroupMember = studyGroupMemberRepository.findByStudyGroupIdAndMemberId(studyGroupId, member.getId())

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -183,7 +183,7 @@ public class StudyGroupService {
 
   @Transactional
   public void softDeleteStudyGroup(Long studyGroupId, Member requester) {
-    var studyGroup = studyGroupRepository.findById(studyGroupId)
+    var studyGroup = studyGroupRepository.findByIdForUpdate(studyGroupId)
         .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
 
     if (!studyGroup.getCreator().getId().equals(requester.getId())) {


### PR DESCRIPTION
## 📌 개요
-  스터디 그룹 참가 인원 조회 및 스터디 그룹 스케쥴 조회 시 읽기 전용 트랜잭션과 비관적락의 충돌에 따른 JPA 기능 분리

## 🛠️ 작업 내용
- 스터디 그룹 관련 조회 기능 제외 갱신이 필요한 기능 `findByIdForUpdate`로 분리

## 📌 차후 계획 (Optional)
- 추가적인 버그 확인 예정

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
-.추가적인 락이 필요한 기능 있는지 확인해주시면 감사하겠습니다
---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

close #380 