### PR TITLE
[Refactor] 스터디 조회 시 삭제 된 스터디 조회 안되도록 조건문 수정

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
@@ -19,6 +19,9 @@ public class StudyGroupDetailResponse {
   private String title;
   private String explanation;
   private String writer;
+  private Long writeMemberId;
+  private Long profileId;
+  private String nickname;
   private int memberCount;
   private int groupLimit;
   private String location;
@@ -39,6 +42,7 @@ public class StudyGroupDetailResponse {
         .title(group.getTitle())
         .explanation(group.getExplanation())
         .writer(group.getCreator().getNickname())
+            .writeMemberId(group.getCreator().getId())
         .memberCount(group.getMembers().size())
         .groupLimit(group.getGroupMemberCount())
         .location(group.getStudyLocation())

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
@@ -22,6 +22,7 @@ public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMemb
   WHERE m.member.id = :memberId
     AND m.isAllowed = true
     AND sg.creator.id <> :memberId
+    AND sg.deleted = false
   ORDER BY sg.createdAt DESC
 """)
   List<StudyGroupMember> findAllByMemberIdAndIsAllowedTrueAndNotCreator(@Param("memberId") Long memberId);

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -28,6 +28,7 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
         OR (:keyword IS NULL OR LOWER(sg.explanation) LIKE LOWER(CONCAT('%', :keyword, '%')))
     )
     AND (:stackNames IS NULL OR ts.name IN :stackNames)
+    AND sg.deleted = false
     AND (:onOffline IS NULL OR
         (:onOffline = 'ONLINE' AND sg.isOffline = false) OR
         (:onOffline = 'OFFLINE' AND sg.isOffline = true) OR
@@ -60,6 +61,9 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
 """)
   List<StudyGroupReply> findRepliesByCommentIds(@Param("commentIds") List<Long> commentIds);
 
+  @Query("SELECT sg FROM StudyGroup sg " +
+          "WHERE sg.creator.id = :memberId AND sg.deleted = false " +
+          "ORDER BY sg.createdAt DESC")
   List<StudyGroup> findAllByCreator_IdOrderByCreatedAtDesc(Long memberId);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)


### PR DESCRIPTION
## 🛠️ 작업 내용
- [ ] 스터디 삭제 시, 스터디장이 삭제했을 시 스터디 목록 조회 + 내 스터디, 프로필에서 내가 만든 스터디 or 내가 참여중 스터디 조회시 삭제된 스터디 목록도 조회되는 이슈때문에 Repository에서 is_deleted=false인 스터디만 조회하도록 코드 수정
- [ ] 스터디장 ID 가 전달이 안되어 상세조회시 스터디장 id 전달되도록 필드값 추가


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.