### PR TITLE
[Fix] 프로필 생성 시 닉네임 없이 생성 가능하도록 수정

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/member/Dto/MemberProfileDto.java
+++ b/src/main/java/com/samsamhajo/deepground/member/Dto/MemberProfileDto.java
@@ -23,7 +23,6 @@ public class MemberProfileDto {
 
     private String profileImage;
 
-    @NotBlank (message = "닉네임을 입력해주세요")
     private String nickname;
 
     @NotBlank(message = "자기소개를 입력해주세요.")


### PR DESCRIPTION




## 📌 개요

 - ProfileDto에 있는 nickname의 @NotBlank 어노테이션 제거
