### PR TITLE
[Fix] localDateTime 필드값 db에 uft로 저장되는 버그 해결

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/global/config/MongoConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/MongoConfig.java
@@ -1,10 +1,16 @@
 package com.samsamhajo.deepground.global.config;
 
+import com.samsamhajo.deepground.global.kstConverter.DateToLocalDateTimeKstConvert;
+import com.samsamhajo.deepground.global.kstConverter.LocalDateTimeToDateKstConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import org.springframework.data.mongodb.MongoDatabaseFactory;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.convert.*;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+import java.util.List;
 
 @Configuration
 @EnableMongoAuditing
@@ -13,4 +19,24 @@ public class MongoConfig {
 //    public MongoTransactionManager transactionManager(MongoDatabaseFactory factory) {
 //        return new MongoTransactionManager(factory);
 //    }
+
+    @Bean
+    public MappingMongoConverter mappingMongoConverter(
+            MongoDatabaseFactory mongoDatabaseFactory,
+            MongoMappingContext mongoMappingContext,
+            LocalDateTimeToDateKstConverter dateKstConverter,
+            DateToLocalDateTimeKstConvert localDateTimeKstConverter
+    )   {
+        DbRefResolver dbRefResolver = new DefaultDbRefResolver (mongoDatabaseFactory);
+        MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);
+
+        converter.setTypeMapper(new DefaultMongoTypeMapper(null));
+
+        converter.setCustomConversions(new MongoCustomConversions(
+                List.of(localDateTimeKstConverter, dateKstConverter)
+        ));
+
+        return converter;
+
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/global/kstConverter/DateToLocalDateTimeKstConvert.java
+++ b/src/main/java/com/samsamhajo/deepground/global/kstConverter/DateToLocalDateTimeKstConvert.java
@@ -1,0 +1,27 @@
+package com.samsamhajo.deepground.global.kstConverter;
+
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+@ReadingConverter
+public class DateToLocalDateTimeKstConvert implements Converter<Date, LocalDateTime> {
+
+    private static final int KST_OFFSET_HOURS = 9;
+
+    @Override
+    public LocalDateTime convert(Date source) {
+        return convertToKst(source);
+    }
+
+    private LocalDateTime convertToKst(Date date) {
+        LocalDateTime localDateTime = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+        return localDateTime.minusHours(KST_OFFSET_HOURS);
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/global/kstConverter/LocalDateTimeToDateKstConverter.java
+++ b/src/main/java/com/samsamhajo/deepground/global/kstConverter/LocalDateTimeToDateKstConverter.java
@@ -1,0 +1,26 @@
+package com.samsamhajo.deepground.global.kstConverter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+@ReadingConverter
+public class LocalDateTimeToDateKstConverter implements Converter<Date, LocalDateTime> {
+
+    private static final int KST_OFFSET_HOURS = 9;
+
+    @Override
+    public LocalDateTime convert(Date source) {
+        return convertToKst(source);
+    }
+
+    private LocalDateTime convertToKst(Date date){
+        LocalDateTime localDateTime = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+        return localDateTime.minusHours(KST_OFFSET_HOURS);
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/Notification.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/Notification.java
@@ -2,6 +2,7 @@ package com.samsamhajo.deepground.notification.entity;
 
 import com.samsamhajo.deepground.global.BaseDocument;
 import lombok.Getter;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -11,6 +12,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 @Getter
 @Document(collection = "notifications")
 @CompoundIndex(def = "{'receiver_id': 1, 'created_at': -1}")
+@SQLRestriction("is_deleted = false")
 public class Notification extends BaseDocument {
 
     @Id


### PR DESCRIPTION
## 📌 개요
- 한국 시간을 db에 저장될 수 있는 customConverter 및 mysql jdbc url 에 한국 시간을 추가했습니다

## 🛠️ 작업 내용
- `DateToLocalDateTimeKstConvert` 작성
- `LocalDateTimeToDateKstConverter` 작성
- mongoConfig에 customConverter 추가
- mysql jdbc url에 ?serverTimezone=Asia/Seoul 추가

## 📌 차후 계획 (Optional)
- 추가 버그 있는지 확인 예정
- 성능 개선 예정

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
close #420 