### PR TITLE
[Refactor] JacksonConfig를 이용해 UTC를 KST로 변환하는 로직추가

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/DeepgroundApplication.java
+++ b/src/main/java/com/samsamhajo/deepground/DeepgroundApplication.java
@@ -1,10 +1,13 @@
 package com.samsamhajo.deepground;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.TimeZone;
 
 @EnableScheduling
 @SpringBootApplication(
@@ -14,6 +17,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
         }
 )
 public class DeepgroundApplication {
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(DeepgroundApplication.class, args);

--- a/src/main/java/com/samsamhajo/deepground/global/config/JacksonConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/JacksonConfig.java
@@ -1,0 +1,58 @@
+package com.samsamhajo.deepground.global.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class JacksonConfig {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public JavaTimeModule javaTimeModule() {
+        JavaTimeModule module = new JavaTimeModule();
+
+        // JSON -> LocalDateTime (역직렬화) 규칙을 KST 기준으로 오버라이드합니다.
+        module.addDeserializer(LocalDateTime.class, new KstLocalDateTimeDeserializer());
+        return module;
+    }
+
+    /**
+     * 클라이언트가 보낸 JSON 문자열(UTC "Z" 포함)을
+     * KST 기준의 LocalDateTime으로 변환하는 커스텀 로직
+     */
+    static class KstLocalDateTimeDeserializer extends StdDeserializer<LocalDateTime> {
+
+        protected KstLocalDateTimeDeserializer() { super(LocalDateTime.class); }
+
+        @Override
+        public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            String text = p.getText();
+            try {
+                // "2025-10-29T08:00:00Z" (Z 정보가 있는 경우)
+                ZonedDateTime zdt = ZonedDateTime.parse(text, DateTimeFormatter.ISO_DATE_TIME);
+
+                // KST 시간대로 변환 (08:00Z -> 17:00+09:00)
+                ZonedDateTime kstZdt = zdt.withZoneSameInstant(KST);
+
+                // KST의 LocalDateTime 값(17:00)을 반환
+                return kstZdt.toLocalDateTime();
+
+            } catch (Exception e) {
+                // "2025-10-29T17:00:00" (Z 정보가 없는 경우 등)
+                // KST라고 가정하고 그대로 파싱 (예외 처리)
+                return LocalDateTime.parse(text, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            }
+        }
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/global/kstConverter/DateToLocalDateTimeKstConvert.java
+++ b/src/main/java/com/samsamhajo/deepground/global/kstConverter/DateToLocalDateTimeKstConvert.java
@@ -14,10 +14,20 @@ import java.util.Date;
 @ReadingConverter
 public class DateToLocalDateTimeKstConvert implements Converter<Date, LocalDateTime> {
 
+//    @Override
+//    public LocalDateTime convert(Date source) {
+//        if (source == null) return null;
+//        return LocalDateTime.ofInstant(source.toInstant(), ZoneOffset.UTC);
+//    }
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul"); // KST 정의
+
     @Override
     public LocalDateTime convert(Date source) {
         if (source == null) return null;
-        return LocalDateTime.ofInstant(source.toInstant(), ZoneOffset.UTC);
+
+        // DB의 UTC Date를 KST LocalDateTime으로 변환
+        return source.toInstant().atZone(KST).toLocalDateTime();
     }
 }
 

--- a/src/main/java/com/samsamhajo/deepground/global/kstConverter/LocalDateTimeToDateKstConverter.java
+++ b/src/main/java/com/samsamhajo/deepground/global/kstConverter/LocalDateTimeToDateKstConverter.java
@@ -14,13 +14,23 @@ import java.util.Date;
 @WritingConverter
 public class LocalDateTimeToDateKstConverter implements Converter<LocalDateTime, Date> {
 
-    private static final int KST_OFFSET_HOURS = 9;
+//    private static final int KST_OFFSET_HOURS = 9;
+//
+//    @Override
+//    public Date convert(LocalDateTime source) {
+//        return convertToKst(source);}
+//
+//        private Date convertToKst(LocalDateTime localDateTime) {
+//            return Timestamp.valueOf(localDateTime.plusHours(KST_OFFSET_HOURS));
+//        }
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul"); // KST 정의
 
     @Override
     public Date convert(LocalDateTime source) {
-        return convertToKst(source);}
+        if (source == null) return null;
 
-        private Date convertToKst(LocalDateTime localDateTime) {
-            return Timestamp.valueOf(localDateTime.plusHours(KST_OFFSET_HOURS));
-        }
+        // Java의 KST LocalDateTime을 UTC Date로 변환하여 DB에 저장
+        return Date.from(source.atZone(KST).toInstant());
+    }
 }


### PR DESCRIPTION
- JacksonConfig를 통해 DTO를 통해 받아오는 UTC시간대값을 KST로 변경하여 시간대 충돌을 없애 UI에 제대로 시간이 표시되도록 JacksonConfig & Application에서 KST시간을 사용하도록 명시하는 코드 추가