### PR TITLE
[Fix] 참여 스터디 그룹 멤버 인원 수 버그 해결

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
 
@@ -68,6 +69,7 @@ public class StudyGroup extends BaseEntity {
     private ChatRoom chatRoom;
 
     @OneToMany(mappedBy = "studyGroup", fetch = FetchType.EAGER)
+    @Where(clause = "study_group_member_status = 2")
     private final Set<StudyGroupMember> members = new HashSet<>();
 
     @OneToMany(mappedBy = "studyGroup")


### PR DESCRIPTION
## 📌 개요
- 스터디 그룹 조회 시, 참여 인원(members)에 가입 승인(APPROVED)된 멤버뿐만 아니라 가입 대기(PENDING) 중인 멤버까지 포함되어 집계되는 버그 발생했습니다

## 🛠️ 작업 내용
- [x] StudyGroup 엔티티의 members 컬렉션 필드에 `@Where(clause = "study_group_member_status = 'APPROVED'")` 어노테이션을 추가

<img width="1000" height="569" alt="image" src="https://github.com/user-attachments/assets/4a7f4c78-9281-47be-9065-0fc7722a8d74" />

## 📌 차후 계획 (Optional)
- publicId로 변경하며 발생한 추가적인 버그 해결 예정

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

close #478 