### PR TITLE
[Refactor] 게시글 조회 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.security:spring-security-messaging'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/src/main/java/com/samsamhajo/deepground/global/config/QuerydslConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.samsamhajo.deepground.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/qna/question/Dto/QuestionCreateRequestDto.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/Dto/QuestionCreateRequestDto.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor
 public class QuestionCreateRequestDto {
 

--- a/src/main/java/com/samsamhajo/deepground/qna/question/Dto/QuestionSummaryDto.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/Dto/QuestionSummaryDto.java
@@ -32,7 +32,7 @@ public class QuestionSummaryDto {
         return new QuestionSummaryDto(q.getId(), q.getTitle(), member, q.getQuestionStatus(), techStacks, answerCount, q.getCreatedAt().toLocalDate(), mediaUrl, imageUrl);
     }
 
-    public QuestionSummaryDto(Long questionId, String title, Member member , QuestionStatus questionStatus , List<String> techStacks, int answerCount, LocalDate createdAt, List<String> mediaUrl, String imageUrl) {
+    public QuestionSummaryDto(Long questionId, String title, Member member, QuestionStatus questionStatus, List<String> techStacks, int answerCount, LocalDate createdAt, List<String> mediaUrl, String imageUrl) {
         this.questionId = questionId;
         this.title = title;
         this.publicId = member.getPublicId();

--- a/src/main/java/com/samsamhajo/deepground/qna/question/controller/QuestionController.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/controller/QuestionController.java
@@ -39,11 +39,9 @@ public class QuestionController {
         QuestionCreateResponseDto questionCreateResponseDto = questionService.createQuestion(questionRequestDto, customUserDetails.getMember().getId());
         GlobalLogger.info("질문 생성 = {}",  questionCreateResponseDto.getQuestionId(), "멤버ID= {}", customUserDetails.getMember().getId());
 
-
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(SuccessResponse.of(QuestionSuccessCode.QUESTION_CREATED, questionCreateResponseDto));
-
     }
 
     @PutMapping(value = "/{questionId}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/samsamhajo/deepground/qna/question/repository/QuestionRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/repository/QuestionRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface QuestionRepository extends JpaRepository<Question, Long> {
+public interface QuestionRepository extends JpaRepository<Question, Long>, QuestionRepositoryCustom {
     Page<Question> findByMemberId(Long memberId, Pageable pageable);
     Page<Question> findAllByDeletedFalse(Pageable pageable);
     Optional<Question> findByIdAndDeletedFalse(Long questionId);

--- a/src/main/java/com/samsamhajo/deepground/qna/question/repository/QuestionRepositoryCustom.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/repository/QuestionRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.samsamhajo.deepground.qna.question.repository;
+
+import com.samsamhajo.deepground.qna.question.Dto.QuestionSummaryDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+
+public interface QuestionRepositoryCustom {
+    Page<QuestionSummaryDto> findQuestionSummaries(Pageable pageable);
+}

--- a/src/main/java/com/samsamhajo/deepground/qna/question/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/repository/QuestionRepositoryImpl.java
@@ -1,0 +1,141 @@
+package com.samsamhajo.deepground.qna.question.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.samsamhajo.deepground.member.entity.QMember;
+import com.samsamhajo.deepground.qna.answer.entity.QAnswer;
+import com.samsamhajo.deepground.qna.question.Dto.QuestionSummaryDto;
+import com.samsamhajo.deepground.qna.question.entity.QQuestion;
+import com.samsamhajo.deepground.qna.question.entity.QQuestionMedia;
+import com.samsamhajo.deepground.qna.question.entity.QQuestionTag;
+import com.samsamhajo.deepground.qna.question.entity.Question;
+import com.samsamhajo.deepground.techStack.entity.QTechStack;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<QuestionSummaryDto> findQuestionSummaries(Pageable pageable) {
+
+        QQuestion q = QQuestion.question;
+        QMember m = QMember.member;
+
+        // 1) Question + Member (페이징)
+        List<Question> questions = queryFactory
+                .selectFrom(q)
+                .leftJoin(q.member, m).fetchJoin()
+                .where(q.deleted.isFalse())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (questions.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<Long> questionIds =
+                questions.stream().map(Question::getId).toList();
+
+        // 2) TechStacks
+        Map<Long, List<String>> techStackMap =
+                getTechStacksByQuestionIds(questionIds);
+
+        // 3) AnswerCount
+        Map<Long, Integer> answerCountMap =
+                getAnswerCountsByQuestionIds(questionIds);
+
+        // 4) MediaUrls
+        Map<Long, List<String>> mediaUrlMap =
+                getMediaUrlsByQuestionIds(questionIds);
+
+        // 5) DTO 변환
+        List<QuestionSummaryDto> summaries = questions.stream()
+                .map(qEntity -> QuestionSummaryDto.of(
+                        qEntity,
+                        techStackMap.getOrDefault(qEntity.getId(), List.of()),
+                        answerCountMap.getOrDefault(qEntity.getId(), 0),
+                        mediaUrlMap.getOrDefault(qEntity.getId(), List.of()),
+                        qEntity.getMember()
+                ))
+                .toList();
+
+        // 전체 개수
+        long total = queryFactory
+                .select(q.count())
+                .from(q)
+                .where(q.deleted.isFalse())
+                .fetchOne();
+
+        return new PageImpl<>(summaries, pageable, total);
+    }
+
+
+    private Map<Long, List<String>> getTechStacksByQuestionIds(List<Long> ids) {
+        QQuestionTag qt = QQuestionTag.questionTag;
+        QTechStack ts = QTechStack.techStack;
+
+        List<Tuple> results = queryFactory
+                .select(qt.question.id, ts.name)
+                .from(qt)
+                .leftJoin(qt.techStack, ts)
+                .where(qt.question.id.in(ids))
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.get(qt.question.id),
+                        Collectors.mapping(
+                                t -> t.get(ts.name),
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    private Map<Long, Integer> getAnswerCountsByQuestionIds(List<Long> ids) {
+        QAnswer a = QAnswer.answer;
+
+        List<Tuple> results = queryFactory
+                .select(a.question.id, a.count())
+                .from(a)
+                .where(a.question.id.in(ids))
+                .groupBy(a.question.id)
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(a.question.id),
+                        t -> t.get(a.count()).intValue()
+                ));
+    }
+
+    private Map<Long, List<String>> getMediaUrlsByQuestionIds(List<Long> ids) {
+        QQuestionMedia qm = QQuestionMedia.questionMedia;
+
+        List<Tuple> results = queryFactory
+                .select(qm.question.id, qm.mediaUrl)
+                .from(qm)
+                .where(qm.question.id.in(ids))
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.get(qm.question.id),
+                        Collectors.mapping(
+                                t -> t.get(qm.mediaUrl),
+                                Collectors.toList()
+                        )
+                ));
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/qna/question/service/QuestionService.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/service/QuestionService.java
@@ -48,27 +48,19 @@ public class QuestionService{
 
     //Question 생성 메서드
     @Transactional
-    /**
-     * public QuestionCreateResponseDTO createQuestion(QuestionCreateRequestDto questionCreateRequestDto, Long memberId) ->
-     * QuestionCreateRequestDto와 memberId를 받아서 QuestionCreateResponseDto로 반환해주는 createQuestion 즉 질문을 생성해주는 함수입니다. 라고 말하고 있는 것이다.
-     */
     public QuestionCreateResponseDto createQuestion(QuestionCreateRequestDto questionCreateRequestDto, Long memberId) {
-        // member 검증 로직
        Member member = commonValidation.MemberValidation(memberId);
 
-       // 질문이라는 객체를 만들건데 아까 우리가 받았던 questionCreateRequestDto에 담긴 제목과 내용, 작성자로 질문이라는 객체를 만들어주세요!
         Question question = Question.of(
                 questionCreateRequestDto.getTitle(),
                 questionCreateRequestDto.getContent(),
                 member
         );
 
-        // Question saved = Question이라는 객체를 saved라는 변수로 활용하기 위해서 questionRepository (즉 질문DB에 저장해주세요)
         Question saved = questionRepository.save(question);
         List<String> mediaUrl = createQuestionMedia(questionCreateRequestDto, question);
         questionTagService.createQuestionTag(question, questionCreateRequestDto.getTechStacks());
 
-        // QuestionCreateResponseDto을 saved(즉 우리가 저장한 Question(질문)으로 조립해서 반환해주세요!)
         return QuestionCreateResponseDto.of(
                 saved,
                 questionCreateRequestDto.getTechStacks(),

--- a/src/main/java/com/samsamhajo/deepground/qna/question/service/QuestionService.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/service/QuestionService.java
@@ -48,21 +48,29 @@ public class QuestionService{
 
     //Question 생성 메서드
     @Transactional
+    /**
+     * public QuestionCreateResponseDTO createQuestion(QuestionCreateRequestDto questionCreateRequestDto, Long memberId) ->
+     * QuestionCreateRequestDto와 memberId를 받아서 QuestionCreateResponseDto로 반환해주는 createQuestion 즉 질문을 생성해주는 함수입니다. 라고 말하고 있는 것이다.
+     */
     public QuestionCreateResponseDto createQuestion(QuestionCreateRequestDto questionCreateRequestDto, Long memberId) {
+        // member 검증 로직
        Member member = commonValidation.MemberValidation(memberId);
 
+       // 질문이라는 객체를 만들건데 아까 우리가 받았던 questionCreateRequestDto에 담긴 제목과 내용, 작성자로 질문이라는 객체를 만들어주세요!
         Question question = Question.of(
                 questionCreateRequestDto.getTitle(),
                 questionCreateRequestDto.getContent(),
                 member
         );
 
+        // Question saved = Question이라는 객체를 saved라는 변수로 활용하기 위해서 questionRepository (즉 질문DB에 저장해주세요)
         Question saved = questionRepository.save(question);
         List<String> mediaUrl = createQuestionMedia(questionCreateRequestDto, question);
         questionTagService.createQuestionTag(question, questionCreateRequestDto.getTechStacks());
 
+        // QuestionCreateResponseDto을 saved(즉 우리가 저장한 Question(질문)으로 조립해서 반환해주세요!)
         return QuestionCreateResponseDto.of(
-                question,
+                saved,
                 questionCreateRequestDto.getTechStacks(),
                 mediaUrl
         );
@@ -154,23 +162,16 @@ public class QuestionService{
     //Question 리스트 조회 메서드
     @Transactional(readOnly = true)
     public QuestionListResponseDto getQuestions(Pageable pageable) {
-        Page<Question> questionPage = questionRepository.findAllByDeletedFalse(pageable);
 
-        List<QuestionSummaryDto> summaries = questionPage.stream()
-                .map(question -> {
-                    Member member = commonValidation.MemberValidation(question.getMember().getId());
-                    List<String> teckStacks = tagService.getStackNamesByQuestionId(question.getId());
-                    int answerCount = answerService.countAnswersByQuestionId(question.getId());
+        Page<QuestionSummaryDto> page =
+                questionRepository.findQuestionSummaries(pageable);
 
-                    List<String> mediaUrl = questionMediaRepository.findAllByQuestionId(question.getId()).stream()
-                            .map(QuestionMedia::getMediaUrl)
-                            .toList();
-
-                    return QuestionSummaryDto.of(question, teckStacks, answerCount, mediaUrl, member);
-                }).toList();
-
-        return QuestionListResponseDto.of(summaries, questionPage.getTotalPages());
+        return QuestionListResponseDto.of(
+                page.getContent(),
+                page.getTotalPages()
+        );
     }
+
 
     //Question 상세 조회 메서드
     @Transactional(readOnly = true)

--- a/src/main/java/com/samsamhajo/deepground/qna/validation/CommonValidation.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/validation/CommonValidation.java
@@ -32,11 +32,6 @@ public class CommonValidation {
     private final AnswerLikeRepository answerLikeRepository;
 
     //Member 공통 Validation 코드
-
-    /**
-     * 즉 member라는 객체를 하나 만들건데 memberRepository.findById(우리가 controller에서 받았던 memberId로 DB에서 회원을 찾았을 때
-     * 없다면 ? MEMBER_NOT_FOUND라는 에러를 발생해주세요! 즉 회원가입이 된 회원인지 아닌지 검증을 하는 로직이다.
-     */
     public Member MemberValidation(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/samsamhajo/deepground/qna/validation/CommonValidation.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/validation/CommonValidation.java
@@ -32,6 +32,11 @@ public class CommonValidation {
     private final AnswerLikeRepository answerLikeRepository;
 
     //Member 공통 Validation 코드
+
+    /**
+     * 즉 member라는 객체를 하나 만들건데 memberRepository.findById(우리가 controller에서 받았던 memberId로 DB에서 회원을 찾았을 때
+     * 없다면 ? MEMBER_NOT_FOUND라는 에러를 발생해주세요! 즉 회원가입이 된 회원인지 아닌지 검증을 하는 로직이다.
+     */
     public Member MemberValidation(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));


### PR DESCRIPTION
## 📌 개요

* 게시글 조회 시 techStacks, answerCount, mediaUrl, member를 따로따로 조회하여 DTO로 조립하는 형식의 코드를 작성했었으나, 
-> 한번 조회 시 총 4번의 쿼리발생으로 N+1 문제 발생

## 🛠️ 작업 내용
- [ ] QueryDSL 사용을 위한 의존성 추가
- [ ] interface, 구현체를 통해 querydsl 실제 구현
- [ ] Service로직에 적용


<img width="480" height="180" alt="image" src="https://github.com/user-attachments/assets/3551ecc4-5cbe-43ce-9f57-2b525946f85c" />


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.